### PR TITLE
add support for ecto query params

### DIFF
--- a/lib/ecto/logger.ex
+++ b/lib/ecto/logger.ex
@@ -4,6 +4,7 @@ defmodule ExJsonLogger.Ecto.Logger do
 
   Logger Metadata available:
    * query - the query as string;
+   * query_params - the query parameters as string;
    * query_time - the time spent executing the query in milliseconds;
    * decode_time - the time spent decoding the result in milliseconds;
    * queue_time - the time spent to check the connection out in milliseconds;
@@ -32,7 +33,8 @@ defmodule ExJsonLogger.Ecto.Logger do
       query_time:  raw_query_time,
       decode_time: raw_decode_time,
       queue_time:  raw_queue_time,
-      query:       query
+      query:       query,
+      params:      query_params
     } = entry
 
     times =
@@ -50,6 +52,7 @@ defmodule ExJsonLogger.Ecto.Logger do
     |> Keyword.put(:query_time, query_time)
     |> Keyword.put(:queue_time, queue_time)
     |> Keyword.put(:query, query)
+    |> Keyword.put(:query_params, inspect(query_params, charlists: false))
 
     Logger.log(level, fn -> {"", metadata} end)
 

--- a/test/ecto/logger_test.exs
+++ b/test/ecto/logger_test.exs
@@ -8,7 +8,8 @@ defmodule ExJsonLogger.Ecto.LoggerTest do
     :db_duration,
     :query,
     :query_time,
-    :queue_time
+    :queue_time,
+    :query_params
   ]
 
   describe "log/2" do
@@ -24,7 +25,8 @@ defmodule ExJsonLogger.Ecto.LoggerTest do
         query_time: 3_638_533,
         decode_time:   79_113,
         queue_time:   123_169,
-        query: "SELECT n0.`id`, n0.`title`, n0.`text`, n0.`created_at`, n0.`inserted_at`, n0.`updated_at` FROM `notes` AS n0"
+        query: "INSERT INTO `x` (`id`, `label`, `updated_at`) VALUES (?,?,?)",
+        params: [1, "20170504-373-cb4150f", {{2017, 5, 10}, {21, 34, 53, 998254}}, {{2017, 5, 10}, {21, 34, 53, 998264}}]
       }
 
       {_, message} = capture_log(fn ->
@@ -35,7 +37,8 @@ defmodule ExJsonLogger.Ecto.LoggerTest do
       assert message =~ "db_duration=3.84 "
       assert message =~ "query_time=3.638 "
       assert message =~ "queue_time=0.123 "
-      assert message =~ "query=SELECT n0.`id`, n0.`title`, n0.`text`, n0.`created_at`, n0.`inserted_at`, n0.`updated_at` FROM `notes` AS n0"
+      assert message =~ "query=INSERT INTO `x` (`id`, `label`, `updated_at`) VALUES (?,?,?)"
+      assert message =~ "query_params=[1, \"20170504-373-cb4150f\", {{2017, 5, 10}, {21, 34, 53, 998254}}, {{2017, 5, 10}, {21, 34, 53, 998264}}]"
     end
   end
 end


### PR DESCRIPTION
Added support for ecto query params.
I'm currently inspecting the param list to make sure log output is valid json.
Let me know if you know of a better alternative. 