### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,14 +2,14 @@ defmodule ExJsonLogger.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/rentpath/ex_json_logger"
-  @version "1.3.0"
+  @version "1.4.0"
 
   def project do
     [
       app: :ex_json_logger,
       name: "ex_json_logger",
       version: @version,
-      elixir: ">= 1.13.0",
+      elixir: ">= 1.14.0",
       elixirc_options: [warnings_as_errors: true],
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-5981)

I forgot to bump the package version in my last PR. I incremented a minor version number because the performance improvement changes changed how references are formatted. Changes to log format may be incompatible with any exist log filters/queries.