### PR TITLE
add failing test for invalid bytes

### DIFF
--- a/test/ex_json_logger_test.exs
+++ b/test/ex_json_logger_test.exs
@@ -61,4 +61,10 @@ defmodule ExJsonLoggerTest do
              "ref" => ^expected_ref
            } = decoded_log
   end
+
+  test "invalid byte" do
+    Logger.configure_backend(:console, metadata: [])
+    message = capture_log(fn -> Logger.debug(<<219, 229>>) end)
+    assert %{"level" => "error", "msg" => "��"} = Jason.decode!(message)
+  end
 end


### PR DESCRIPTION
This PR adds a failing test for invalid unicode bytes. Should they be escaped with `�`?

---

There is a function that can be used, `Logger.Formatter.prune`, but it's not very optimized, so calling it on all binaries would slow the formatter down (current benchmarks show it's a ~30% slowdown).

```elixir
iex> Logger.Formatter.prune <<219, 229>>
"��"
```

I'll check if Elixir team is open to making `Logger.Formatter.prune` a bit faster.